### PR TITLE
Implement support for nested enums

### DIFF
--- a/annotations/src/main/java/org/cmoine/genericEnums/GenericEnumOuterClass.java
+++ b/annotations/src/main/java/org/cmoine/genericEnums/GenericEnumOuterClass.java
@@ -1,0 +1,18 @@
+package org.cmoine.genericEnums;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to specify the name of the generated outer class.
+ * <p>
+ * If name is not specified, the original name is used with a "Ext" suffix.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface GenericEnumOuterClass {
+
+    String name() default "%Ext";
+}

--- a/it/src/main/java/org/cmoine/genericEnums/OuterClass.java
+++ b/it/src/main/java/org/cmoine/genericEnums/OuterClass.java
@@ -1,0 +1,14 @@
+package org.cmoine.genericEnums;
+
+public class OuterClass {
+
+    @GenericEnum
+    public enum InnerEnum {
+        ONE(int.class),
+        TWO(String.class);
+
+        InnerEnum(Class<?> clazz) {
+
+        }
+    }
+}

--- a/it/src/main/java/org/cmoine/genericEnums/OuterClassWithSpecificName.java
+++ b/it/src/main/java/org/cmoine/genericEnums/OuterClassWithSpecificName.java
@@ -1,0 +1,20 @@
+package org.cmoine.genericEnums;
+
+@GenericEnumOuterClass(name="MyOuterClass")
+public class OuterClassWithSpecificName {
+
+    @GenericEnum(name="InnerEnum")
+    public enum InnerEnum {
+        ONE(int.class),
+        TWO(String.class);
+
+        InnerEnum(Class<?> clazz) {
+
+        }
+
+        @Override
+        public String toString() {
+            return ordinal() + ": " + name();
+        }
+    }
+}

--- a/it/src/main/java/org/cmoine/genericEnums/SerializableOuterClass.java
+++ b/it/src/main/java/org/cmoine/genericEnums/SerializableOuterClass.java
@@ -1,0 +1,17 @@
+package org.cmoine.genericEnums;
+
+import java.io.Serializable;
+
+public class SerializableOuterClass implements Serializable {
+    private final static long serialVersionUID = 123L;
+
+    @GenericEnum
+    public enum InnerEnum {
+        ONE(int.class),
+        TWO(String.class);
+
+        InnerEnum(Class<?> clazz) {
+
+        }
+    }
+}

--- a/it/src/test/java/org/cmoine/genericEnums/GenericEnumTest.java
+++ b/it/src/test/java/org/cmoine/genericEnums/GenericEnumTest.java
@@ -1,5 +1,6 @@
 package org.cmoine.genericEnums;
 
+import java.io.Serializable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ public class GenericEnumTest {
     @Test
     public void testIllegalArgumentException() {
         IllegalArgumentException e = Assert.assertThrows(IllegalArgumentException.class, () -> SimpleGenericEnumExt.valueOf(NON_EXISTENT_ENUM_NAME));
-        Assert.assertEquals("No enum constant org.cmoine.genericEnums.SimpleGenericEnumExt.NON_EXISTENT", e.getMessage());
+        Assert.assertEquals("No enum constant NON_EXISTENT", e.getMessage());
     }
 
     @Test
@@ -66,5 +67,21 @@ public class GenericEnumTest {
         Assert.assertEquals(false, IsDefaultExt.INT.test(1));
         Assert.assertEquals(true, IsDefaultExt.STRING.test(""));
         Assert.assertEquals(false, IsDefaultExt.STRING.test(null));
+    }
+
+    @Test
+    public void testOuterClass() {
+        Assert.assertEquals(ENUM_NAME, OuterClassExt.InnerEnumExt.ONE.name());
+    }
+
+    @Test
+    public void testOuterClassExplicitlyNamed() {
+        Assert.assertEquals(ENUM_NAME, MyOuterClass.InnerEnum.ONE.name());
+    }
+
+    @Test
+    public void testImplementsNonGenericInterface() {
+        Assert.assertTrue(Serializable.class.isAssignableFrom(SerializableOuterClassExt.class));
+        Assert.assertTrue(Serializable.class.isAssignableFrom(SerializableOuterClassExt.InnerEnumExt.class));
     }
 }

--- a/processor/src/main/java/org/cmoine/genericEnums/processor/GenericEnumProcessor.java
+++ b/processor/src/main/java/org/cmoine/genericEnums/processor/GenericEnumProcessor.java
@@ -6,6 +6,10 @@ import com.sun.source.util.Trees;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.io.Writer;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.QualifiedNameable;
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor;
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType;
 import org.cmoine.genericEnums.GenericEnum;
@@ -19,10 +23,8 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -70,32 +72,68 @@ public class GenericEnumProcessor extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         for (TypeElement te : annotations) {
-            Set<? extends Element> elementsAnnotatedWith = roundEnv.getElementsAnnotatedWith(te);
-            for (Element elt : elementsAnnotatedWith) {
-                generate((TypeElement) elt);
+            final Map<TypeElement, Set<TypeElement>> groupedElements = groupElementsByContainer(roundEnv.getElementsAnnotatedWith(te));
+
+            for (Map.Entry<TypeElement, Set<TypeElement>> entry : groupedElements.entrySet()) {
+                generate(entry.getKey(), entry.getValue());
             }
         }
         return true;
     }
 
-    private void generate(TypeElement typeElement) {
-        try {
-            dump(typeElement, 0);
-            String pkgName = getPackageName(typeElement);
+    /**
+     * Collate annotated enum TypeElements by their top-level TypeElement. If the source enum is a top-level
+     * (i.e. It's parent is a package) then its top-level element is itself.
+     *
+     * @param elementsAnnotatedWith A set of TypeElements annotated with {@link GenericEnum}.
+     * @return A map of top-level TypeElements to source enum TypeElements.
+     */
+    private Map<TypeElement, Set<TypeElement>> groupElementsByContainer(
+        Set<? extends Element> elementsAnnotatedWith) {
+        final Map<TypeElement, Set<TypeElement>> groupedElements = new HashMap<>();
 
-            String className = typeElement.getAnnotation(GenericEnum.class).name().replace("%", typeElement.getSimpleName());
-            // String className = typeElement.getSimpleName().toString() + "Ext";
-            JavaFileObject sourceFile = processingEnv.getFiler()
-                    .createSourceFile(pkgName + "." + className,
-                            typeElement);
+        for (Element element : elementsAnnotatedWith) {
+            if (element.getEnclosingElement() != null && element.getEnclosingElement().getKind().isClass()) {
+                Set<TypeElement> elements = groupedElements.computeIfAbsent((TypeElement) element.getEnclosingElement(), (e) -> new LinkedHashSet<>());
+                elements.add((TypeElement) element);
+
+            } else {
+                groupedElements.put((TypeElement) element, new LinkedHashSet<>(Collections.singletonList((TypeElement) element)));
+            }
+        }
+
+        return groupedElements;
+    }
+
+    /**
+     * Generate pseudo enum declarations using the specified top-level TypeElement and source enum TypeElements.
+     *
+     * @param topLevelTypeElement The source top-level TypeElement
+     * @param enumElements The set of source enum TypeElements to process
+     */
+    private void generate(TypeElement topLevelTypeElement, Set<TypeElement> enumElements) {
+        try {
+            dump(topLevelTypeElement, 0);
+            final String pkgName = getPackageName(topLevelTypeElement);
+            final TypeElementWrapper typeElementWrapper = new TypeElementWrapper(trees, topLevelTypeElement);
+            final JavaFileObject sourceFile = processingEnv.getFiler().createSourceFile(pkgName + "." + typeElementWrapper.getClassName(), topLevelTypeElement);
+            final TemplateData dataModel = new TemplateData(getClass(),
+                processingEnv,
+                pkgName,
+                typeElementWrapper,
+                enumElements
+                    .stream()
+                    .map((el) -> new TypeElementWrapper(trees, el))
+                    .collect(Collectors.toSet()));
+
             try (Writer writer = sourceFile.openWriter()) {
                 Configuration cfg = new Configuration(Configuration.VERSION_2_3_29);
                 cfg.setClassLoaderForTemplateLoading(getClass().getClassLoader(),
                         getClass().getPackage().getName().replace('.', '/'));
                 cfg.setSharedVariable("instanceOf", new InstanceOfMethod());
-                Template template = cfg.getTemplate("template.ftl");
-                template.createProcessingEnvironment(new TemplateData(getClass(),
-                        processingEnv, pkgName, className, new TypeElementWrapper(trees, typeElement)), writer).process();
+
+                final Template template = cfg.getTemplate("template.ftl");
+                template.createProcessingEnvironment(dataModel, writer).process();
             } catch (TemplateException e) {
                 print(e);
             }
@@ -137,11 +175,20 @@ public class GenericEnumProcessor extends AbstractProcessor {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, stringWriter.toString());
     }
 
-    private static String getPackageName(TypeElement te) {
-        String qualifiedName = te.getQualifiedName().toString();
-        int index = qualifiedName.lastIndexOf('.');
-        if (index > 0)
-            return qualifiedName.substring(0, index);
-        return qualifiedName;
+    /**
+     * Get the name of the container package for the specified {@link QualifiedNameable}.
+     *
+     * @param qualifiedNameable the contained element
+     * @return the name of the nearest parent package
+     */
+    private static String getPackageName(QualifiedNameable qualifiedNameable) {
+        while (qualifiedNameable != null) {
+            if (qualifiedNameable.getKind() == ElementKind.PACKAGE) {
+                return qualifiedNameable.getQualifiedName().toString();
+            }
+            qualifiedNameable = (QualifiedNameable) qualifiedNameable.getEnclosingElement();
+        }
+
+        return "";
     }
 }

--- a/processor/src/main/java/org/cmoine/genericEnums/processor/model/InterfaceTreeWrapper.java
+++ b/processor/src/main/java/org/cmoine/genericEnums/processor/model/InterfaceTreeWrapper.java
@@ -1,6 +1,7 @@
 package org.cmoine.genericEnums.processor.model;
 
 import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.Tree;
 import org.cmoine.genericEnums.processor.util.TreeUtil;
@@ -28,6 +29,8 @@ public class InterfaceTreeWrapper {
             String genericParamName = TreeUtil.getGenericParamName(att.getAnnotations());
             if(genericParamName!=null)
                 return genericParamName;
+        } else if (tree instanceof IdentifierTree) {
+            return ((IdentifierTree) tree).getName().toString();
         }
         return tree.getClass().toString();
 //        DeclaredType declaredType= (DeclaredType) typeMirror;

--- a/processor/src/main/resources/org/cmoine/genericEnums/processor/template.ftl
+++ b/processor/src/main/resources/org/cmoine/genericEnums/processor/template.ftl
@@ -1,23 +1,31 @@
 package ${packageName};
 
-<#list typeElement.imports as import>${import}</#list>
-<#if generatedTypeAvailable>
-import ${generatedType};
+<#list imports as import>
+${import}
+</#list>
 
+<#t><#if outerClass>
+<#t><#if !generatedTypeAvailable>/*</#if>
+@Generated(
+    value = "${processorName}",
+    date = "${.now?string("yyyy-MM-dd'T'HH:mm:ssZ")}",
+    comments = "version: ${version!"[N/A]"}, compiler: javac, environment: Java ${runtimeVersion} (${runtimeVendor})"
+)<#if !generatedTypeAvailable>*/</#if>
+public <#if typeElement.static>static </#if><#if typeElement.abstract>abstract </#if>class ${typeElement.className}<#if typeElement.genericParameterNames?has_content><${typeElement.genericParameterNames?join(', ')}></#if> <#if typeElement.interfaceTree?has_content>implements ${typeElement.interfaceTree?join(', ')} </#if>{
 </#if>
-
+<#list enumTypeElements as typeElement>
 <#if !generatedTypeAvailable>/*</#if>
 @Generated(
     value = "${processorName}",
     date = "${.now?string("yyyy-MM-dd'T'HH:mm:ssZ")}",
     comments = "version: ${version!"[N/A]"}, compiler: javac, environment: Java ${runtimeVersion} (${runtimeVendor})"
 )<#if !generatedTypeAvailable>*/</#if>
-public <#if typeElement.abstract>abstract </#if>class ${className}<${typeElement.genericParameterNames?join(', ')}> <#if typeElement.interfaceTree?has_content>implements ${typeElement.interfaceTree?join(', ')}</#if>{
+public <#if typeElement.static>static </#if><#if typeElement.abstract>abstract </#if>class ${typeElement.className}<#if typeElement.genericParameterNames?has_content><${typeElement.genericParameterNames?join(', ')}></#if> <#if typeElement.interfaceTree?has_content>implements ${typeElement.interfaceTree?join(', ')} </#if>{
 <#list typeElement.enumConstantTree as enumConstant>
 <#assign enums = enumConstant.arguments />
 <#assign enums += ['"'+enumConstant.name+'"'] />
 <#assign enums += [enumConstant?index] />
-    public static final ${className}<${enumConstant.types?join(', ')}> ${enumConstant.name}=new ${className}<${enumConstant.types?join(', ')}>(${enums?join(', ')})<#if enumConstant.classBody??> {
+    public static final ${typeElement.className}<${enumConstant.types?join(', ')}> ${enumConstant.name} = new ${typeElement.className}<${enumConstant.types?join(', ')}>(${enums?join(', ')})<#if enumConstant.classBody??> {
 <#list enumConstant.classBody.fields as field>
 <#assign pad="            "/>
 <#include "fieldTree.ftl"/>
@@ -28,6 +36,8 @@ public <#if typeElement.abstract>abstract </#if>class ${className}<${typeElement
 </#list>
         }</#if>;
 </#list>
+
+    private final static long serialVersionUID = 1L;
     private final String __enum_name__;
     private final int __ordinal__;
 <#list typeElement.fieldTree as field>
@@ -39,7 +49,7 @@ public <#if typeElement.abstract>abstract </#if>class ${className}<${typeElement
 <#assign params = constructor.parameters?map(it -> it.type+' '+it.name) />
 <#assign params += ["String __enum_name__"] />
 <#assign params += ["int __ordinal__"] />
-    private ${className}(${params?join(', ')}) {
+    private ${typeElement.className}(${params?join(', ')}) {
 <#list constructor.statements as statement>
 <#if statement?index==0 && constructor.thisInitializer??>
 <#assign args = constructor.thisInitializer.arguments />
@@ -62,29 +72,53 @@ public <#if typeElement.abstract>abstract </#if>class ${className}<${typeElement
 <#include "methodTree.ftl"/>
 </#list>
 
-    public static ${className}[] values() {
-        return new ${className}[]{${typeElement.enumConstantTree?map(it -> it.name)?join(', ')}};
+    public static ${typeElement.className}[] values() {
+        return new ${typeElement.className}[]{${typeElement.enumConstantTree?map(it -> it.name)?join(', ')}};
     }
 
-    public static ${className} valueOf(String name) {
+    public static ${typeElement.className} valueOf(String name) {
 <#list typeElement.enumConstantTree as enumConstant>
         if("${enumConstant.name}".equals(name)) {
             return ${enumConstant.name};
         }
 </#list>
-        throw new IllegalArgumentException("No enum constant ${packageName}.${className}."+name);
+        throw new IllegalArgumentException("No enum constant " + name);
     }
 
-    public String name() {
+    public final String name() {
         return this.__enum_name__;
     }
 
-    public int ordinal() {
+    public final int ordinal() {
         return this.__ordinal__;
     }
+
+    @Override
+    public final boolean equals(Object other) {
+        return this==other;
+    }
+
+    @Override
+    public final int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public final int compareTo(${typeElement.className}<${typeElement.genericParameterNames?join(', ')}> other) {
+        if (getClass() != other.getClass()) {
+            throw new ClassCastException();
+        }
+        return this.__ordinal__ - other.__ordinal__;
+    }
+<#if !typeElement.toStringMethodPresent>
 
     @Override
     public String toString() {
         return name();
     }
+</#if>
 }
+</#list>
+<#if outerClass>
+}
+</#if>


### PR DESCRIPTION
Implement support for enums within classes. Currently only support nesting of one level.
Added support for non-generic interfaces (e.g. Serializable)

```
public class MyClass implements Serializable {

  public enum MyEnum {
    ONE, TWO
  }
}
```

Added integration tests.