### PR TITLE
Implement support default types.

### DIFF
--- a/annotations/src/main/java/org/cmoine/genericEnums/GenericEnumConstructorParam.java
+++ b/annotations/src/main/java/org/cmoine/genericEnums/GenericEnumConstructorParam.java
@@ -1,0 +1,51 @@
+package org.cmoine.genericEnums;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specify a mapping between a type argument name and its type. Used to specify types (instead of
+ * constructor parameters).
+ *
+ * <p>
+ *
+ * <p>If <code>name</code> is not specified, <code>"T"</code> will be used, then <code>"U"</code>
+ * etc.
+ *
+ * <pre>
+ *   MyEnum {
+ *     STRING,
+ *     ANOTHER_STRING,
+ *     INTEGER(int.class);
+ *
+ *     &#64;GenericEnumConstructorParam(name = "T", type = String.class)
+ *     MyEnum() {
+ *       this(String.class);
+ *     }
+ *
+ *     MyEnum(Class&lt;?&gt; clazz) {
+ *       ...
+ *     }
+ *
+ *   ...
+ *
+ *   &#64;GenericEnumConstructorParam(name = "T", type = String.class)
+ *   &#64;GenericEnumConstructorParam(name = "U", type = int.class)
+ *   MyOtherEnum() {
+ *     this(String.class, int.class);
+ *   }
+ * </pre>
+ *
+ * <p>Can be specified multiple times.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.CONSTRUCTOR})
+@Repeatable(value = GenericEnumConstructorParams.class)
+public @interface GenericEnumConstructorParam {
+  String name() default "";
+
+  Class<?> type();
+}

--- a/annotations/src/main/java/org/cmoine/genericEnums/GenericEnumConstructorParams.java
+++ b/annotations/src/main/java/org/cmoine/genericEnums/GenericEnumConstructorParams.java
@@ -1,0 +1,27 @@
+package org.cmoine.genericEnums;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specify mappings between type argument names and their types.
+ *
+ * <pre>
+ *   &#64;GenericEnumConstructorParams({
+ *     &#64;GenericEnumConstructorParams(String.class)
+ *     &#64;GenericEnumConstructorParams(int.class)
+ *   })
+ *   MyClass() {
+ *     this(String.class, int.class);
+ *   }
+ * </pre>
+ *
+ * See {@link GenericEnumConstructorParam} for more details.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.CONSTRUCTOR})
+public @interface GenericEnumConstructorParams {
+    GenericEnumConstructorParam[] value() default {};
+}

--- a/it/src/main/java/org/cmoine/genericEnums/PolymorphicConstructorEnum.java
+++ b/it/src/main/java/org/cmoine/genericEnums/PolymorphicConstructorEnum.java
@@ -2,14 +2,20 @@ package org.cmoine.genericEnums;
 
 @GenericEnum
 public enum PolymorphicConstructorEnum {
+    ZERO_PARAM,
     ONE_PARAM(int.class),
-    TWO_PARAM(int.class, 1);
+    TWO_PARAM(int.class, 2);
 
     private final Class<?> clazz;
     private final int _default;
 
+    @GenericEnumConstructorParam(type = int.class)
+    PolymorphicConstructorEnum() {
+        this(int.class, 0);
+    }
+
     PolymorphicConstructorEnum(Class<?> clazz) {
-        this(clazz, 0);
+        this(clazz, 1);
     }
 
     PolymorphicConstructorEnum(Class<?> clazz, int _default) {

--- a/it/src/test/java/org/cmoine/genericEnums/GenericEnumTest.java
+++ b/it/src/test/java/org/cmoine/genericEnums/GenericEnumTest.java
@@ -51,8 +51,9 @@ public class GenericEnumTest {
 
     @Test
     public void testPolymorphicConstructor() {
-        Assert.assertEquals(0, PolymorphicConstructorEnumExt.ONE_PARAM.get_default());
-        Assert.assertEquals(1, PolymorphicConstructorEnumExt.TWO_PARAM.get_default());
+        Assert.assertEquals(0, PolymorphicConstructorEnumExt.ZERO_PARAM.get_default());
+        Assert.assertEquals(1, PolymorphicConstructorEnumExt.ONE_PARAM.get_default());
+        Assert.assertEquals(2, PolymorphicConstructorEnumExt.TWO_PARAM.get_default());
     }
 
     @Test

--- a/processor/src/main/java/org/cmoine/genericEnums/processor/model/ArgumentWrapper.java
+++ b/processor/src/main/java/org/cmoine/genericEnums/processor/model/ArgumentWrapper.java
@@ -1,8 +1,8 @@
 package org.cmoine.genericEnums.processor.model;
 
-import com.google.common.primitives.Primitives;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
+import org.cmoine.genericEnums.processor.util.TreeUtil;
 
 public class ArgumentWrapper {
     final ExpressionTree expr;
@@ -14,12 +14,7 @@ public class ArgumentWrapper {
         isClass=expr instanceof MemberSelectTree && "class".equals(((MemberSelectTree) expr).getIdentifier().toString());
         if(isClass) {
             String type = ((MemberSelectTree) expr).getExpression().toString();
-            for(Class<?> clazz: Primitives.allPrimitiveTypes()) {
-                if(clazz.toString().equals(type)) {
-                    type =Primitives.wrap(clazz).getSimpleName();
-                    break;
-                }
-            }
+            type = TreeUtil.getBoxedClassName(type);
             this.type=type;
         } else {
             this.type=null;

--- a/processor/src/main/java/org/cmoine/genericEnums/processor/model/ConstructorTreeWrapper.java
+++ b/processor/src/main/java/org/cmoine/genericEnums/processor/model/ConstructorTreeWrapper.java
@@ -1,7 +1,10 @@
 package org.cmoine.genericEnums.processor.model;
 
 import com.sun.source.tree.*;
+import java.util.Collections;
 import org.cmoine.genericEnums.GenericEnumConstants;
+import org.cmoine.genericEnums.GenericEnumConstructorParam;
+import org.cmoine.genericEnums.GenericEnumConstructorParams;
 import org.cmoine.genericEnums.processor.util.TreeUtil;
 
 import java.util.ArrayList;
@@ -46,22 +49,46 @@ public class ConstructorTreeWrapper extends AbstractMethodTreeWrapper {
                 .collect(Collectors.toList());
     }
 
-    public List<String> getGenericParameters() {
-        List<String> result=new ArrayList<>();
-        char genericParamName= GenericEnumConstants.GENERIC_NAME.charAt(0);
-        List<? extends VariableTree> parameters = methodTree.getParameters();
-        for (int i = 0; i < parameters.size(); i++) {
-            VariableTree parameter = parameters.get(i);
-            if(parameter.getType().toString().startsWith("Class")) {
-                String annotation = TreeUtil.getGenericParamName(parameter.getModifiers());
-                if (annotation != null) {
-                    result.add(annotation);
-                } else if (TreeUtil.getSymbol(parameter).asType().toString().startsWith(Class.class.getName())) {
-                    result.add(Character.toString(genericParamName));
-                    genericParamName++;
+  /**
+   * Get a list of generic names associated with this constructor. "T", "U", etc.
+   * <p>
+   * Use <code>&#64;GenericEnumConstructorParam(s)</code> annotations if present, otherwise examine the parameters.
+   *
+   * @return a list containing type names e.g. "T", "U".
+   */
+  public List<String> getGenericParameters() {
+        if (TreeUtil.hasAnnotation(methodTree.getModifiers().getAnnotations(), GenericEnumConstructorParam.class) ||
+            TreeUtil.hasAnnotation(methodTree.getModifiers().getAnnotations(), GenericEnumConstructorParams.class)) {
+            return TreeUtil.getGenericConstructorParams(methodTree.getModifiers().getAnnotations(), "name");
+
+        } else {
+            final List<String> result=new ArrayList<>();
+            char genericParamName= GenericEnumConstants.GENERIC_NAME.charAt(0);
+            List<? extends VariableTree> parameters = methodTree.getParameters();
+            for (int i = 0; i < parameters.size(); i++) {
+                VariableTree parameter = parameters.get(i);
+                if(parameter.getType().toString().startsWith("Class")) {
+                    String annotation = TreeUtil.getGenericParamName(parameter.getModifiers());
+                    if (annotation != null) {
+                        result.add(annotation);
+                    } else if (TreeUtil.getSymbol(parameter).asType().toString().startsWith(Class.class.getName())) {
+                        result.add(Character.toString(genericParamName));
+                        genericParamName++;
+                    }
                 }
             }
+
+            return result;
         }
-        return result;
     }
+
+  public List<String> getGenericParametersTypes() {
+    if (TreeUtil.hasAnnotation(methodTree.getModifiers().getAnnotations(), GenericEnumConstructorParam.class)
+        || TreeUtil.hasAnnotation(methodTree.getModifiers().getAnnotations(), GenericEnumConstructorParams.class)) {
+
+      return TreeUtil.getGenericConstructorParams(methodTree.getModifiers().getAnnotations(), "type");
+    }
+
+    return Collections.emptyList();
+  }
 }


### PR DESCRIPTION
Allow enum types to be declared without explicitly specifying class types. Add an annotation (or multiple) on a constructor to define the expected types (instead of inferring them from constructor parameters).